### PR TITLE
Validations

### DIFF
--- a/packages/form/src/components/BlitzField.vue
+++ b/packages/form/src/components/BlitzField.vue
@@ -561,7 +561,15 @@ export default defineComponent({
 
       if (isFullString(requiredErrorResult)) return requiredErrorResult
 
-      return evalPropOrAttr('error') || null
+      const errorStatus = evalPropOrAttr('error')
+      if (isBoolean(errorStatus)) {
+        if (errorStatus) {
+          const errorMessage = evalPropOrAttr('errorMessage')
+          return errorMessage ? errorMessage : langCalculated['fieldValidationError']
+        }
+        return null
+      }
+      return errorStatus || null
     },
     // validate() IS CALLED FROM REFERENCE!!
     /**

--- a/packages/form/src/components/BlitzField.vue
+++ b/packages/form/src/components/BlitzField.vue
@@ -558,7 +558,6 @@ export default defineComponent({
       const isRequired = evalPropOrAttr('required')
       const requiredErrorFn = createRequiredErrorFn(langCalculated['requiredField'])
       const requiredErrorResult = !isRequired ? null : requiredErrorFn(cValue)
-
       if (isFullString(requiredErrorResult)) return requiredErrorResult
 
       const errorStatus = evalPropOrAttr('error')

--- a/packages/form/src/helpers/validation.js
+++ b/packages/form/src/helpers/validation.js
@@ -1,9 +1,9 @@
 import { flattenPerSchema } from '@blitzar/utils'
-import { isArray, isFullString, isFunction } from 'is-what'
+import { isArray, isBoolean, isFullString, isFunction } from 'is-what'
 import { defaultLang } from '../meta/lang'
 
 export function createRequiredErrorFn(requiredFieldErrorMsg) {
-  return (val) => (val === 0 || !!val) ? null : requiredFieldErrorMsg
+  return (val) => !(val === null || val === undefined) ? null : requiredFieldErrorMsg
 }
 
 /**
@@ -21,15 +21,38 @@ export function createRequiredErrorFn(requiredFieldErrorMsg) {
  * @returns {null | string}
  */
 export function validateFieldPerSchema(payload, blueprint, context = {}) {
-  const lang = context.lang || defaultLang()
-  const requiredErrorFn = createRequiredErrorFn(lang.requiredField)
+  // check whether the field is shown
+  let isVisible = true
+  if (isFunction(blueprint.showCondition)) {
+    isVisible = blueprint.showCondition(payload, context)
+  }
+  if (!isVisible) return null
 
-  const requiredResult = requiredErrorFn(payload)
-  if (isFullString(requiredResult)) return requiredResult
+  // check whether the field is required
+  let isRequired = false
+  if (isFunction(blueprint.required)) {
+    isRequired = blueprint.required(payload, context)
+  } else if (isBoolean(blueprint.required)) {
+    isRequired = blueprint.required
+  }
+
+  if (isRequired) {
+    const lang = context.lang || defaultLang()
+    const requiredErrorFn = createRequiredErrorFn(lang.requiredField)
+    const requiredResult = requiredErrorFn(payload)
+    if (isFullString(requiredResult)) return requiredResult
+  }
 
   if (!blueprint.error) return null
   
-  const errorResult = !isFunction(blueprint.error) ? blueprint.error : blueprint.error(payload, context)
+  let errorResult = !isFunction(blueprint.error) ? blueprint.error : blueprint.error(payload, context)
+  // report provided error message if error result is true
+  if (isBoolean(errorResult)) {
+    if (errorResult) {
+      return blueprint.errorMessage ? blueprint.errorMessage : lang.fieldValidationError
+    }
+    return null
+  }
   return errorResult
 }
 

--- a/packages/form/src/helpers/validation.js
+++ b/packages/form/src/helpers/validation.js
@@ -3,7 +3,7 @@ import { isArray, isBoolean, isFullString, isFunction } from 'is-what'
 import { defaultLang } from '../meta/lang'
 
 export function createRequiredErrorFn(requiredFieldErrorMsg) {
-  return (val) => !(val === null || val === undefined) ? null : requiredFieldErrorMsg
+  return (val) => (val === 0 || !!val) ? null : requiredFieldErrorMsg
 }
 
 /**

--- a/packages/form/src/meta/lang.ts
+++ b/packages/form/src/meta/lang.ts
@@ -9,5 +9,6 @@ export const defaultLang = (): StringObject => ({
   edit: 'Edit',
   save: 'Save',
   requiredField: 'Field is required',
+  fieldValidationError: 'Field has validation error',
   formValidationError: 'There are remaining errors.',
 })


### PR DESCRIPTION
While attempting to make a multi-step form (using the `showCondition` to hide fields that are not part of the current step), I had the issue that "on next step" action, the `validateFormPerSchema()` call was returning errors from the hidden fields. I could have ignored errors from the fields that are not in the step (extra work), but for the form logic it is still problematic to have errors on fields that can be modified.

=> `validateFieldPerSchema()` does not perform validations on fields for which `showCondition` is false. 

I had also the issue that the `error` prop is expected to be a Boolean by Quasar's `QInput`. 

=> In `validateFieldPerSchema()` and in `evaluateError()`, when `error` is a Boolean and is `false`, the error message is looked up in the `errorMessage` prop (if not found, a default `fieldValidationError` is shown). When `error` prop returns a string the original behavior is still operational.
