### PR TITLE
Validations

### DIFF
--- a/packages/form/src/BlitzField.vue
+++ b/packages/form/src/BlitzField.vue
@@ -142,6 +142,7 @@ export default defineComponent({
         edit: 'Edit',
         save: 'Save',
         requiredField: 'Field is required',
+        fieldValidationError: 'Field has validation error',
         formValidationError: 'There are remaining errors.',
       }),
     },

--- a/packages/form/src/BlitzField.vue
+++ b/packages/form/src/BlitzField.vue
@@ -725,7 +725,15 @@ export default defineComponent({
 
       if (isFullString(requiredErrorResult)) return requiredErrorResult
 
-      return evalPropOrAttr('error') || null
+      const errorStatus = evalPropOrAttr('error')
+      if (isBoolean(errorStatus)) {
+        if (errorStatus) {
+          const errorMessage = evalPropOrAttr('errorMessage')
+          return errorMessage ? errorMessage : langCalculated['fieldValidationError']
+        }
+        return null
+      }
+      return errorStatus || null
     },
     // validate() IS CALLED FROM REFERENCE!!
     /**

--- a/packages/form/src/BlitzForm.vue
+++ b/packages/form/src/BlitzForm.vue
@@ -129,6 +129,7 @@ export default defineComponent({
         edit: 'Edit',
         save: 'Save',
         requiredField: 'Field is required',
+        fieldValidationError: 'Field has validation error',
         formValidationError: 'There are remaining errors.',
       }),
     },

--- a/packages/form/src/lang.ts
+++ b/packages/form/src/lang.ts
@@ -10,5 +10,6 @@ export const defaultLang: () => Lang = () => ({
   edit: 'Edit',
   save: 'Save',
   requiredField: 'Field is required',
+  fieldValidationError: 'Field has validation error',
   formValidationError: 'There are remaining errors.',
 })

--- a/packages/form/src/validation.ts
+++ b/packages/form/src/validation.ts
@@ -6,7 +6,7 @@ import { defaultLang } from './lang'
 export function createRequiredErrorFn(
   requiredFieldErrorMsg: string
 ): (payload: any) => null | string {
-  return (val) => (val === 0 || !!val ? null : requiredFieldErrorMsg)
+  return (val) => (isBoolean(val) || val === 0 || !!val ? null : requiredFieldErrorMsg)
 }
 
 /**
@@ -46,7 +46,7 @@ export function validateFieldPerSchema(
 
   if (!blueprint.error) return null
 
-  let errorResult = !isFunction(blueprint.error)
+  const errorResult = !isFunction(blueprint.error)
     ? blueprint.error
     : blueprint.error(payload, context)
   // report provided error message if error result is true

--- a/packages/form/src/validation.ts
+++ b/packages/form/src/validation.ts
@@ -1,5 +1,5 @@
 import { flattenPerSchema } from '@blitzar/utils'
-import { isFullString, isFunction } from 'is-what'
+import { isBoolean, isFullString, isFunction } from 'is-what'
 import type { BlitzFieldProps, FormContext, Lang, Schema } from '@blitzar/types'
 import { defaultLang } from './lang'
 
@@ -22,17 +22,41 @@ export function validateFieldPerSchema(
   blueprint: BlitzFieldProps,
   context: FormContext
 ): null | string {
-  const lang = context.lang || defaultLang()
-  const requiredErrorFn = createRequiredErrorFn(lang.requiredField)
+  // check whether the field is shown
+  let isVisible = true
+  if (isFunction(blueprint.showCondition)) {
+    isVisible = blueprint.showCondition(payload, context)
+  }
+  if (!isVisible) return null
 
-  const requiredResult = requiredErrorFn(payload)
-  if (isFullString(requiredResult)) return requiredResult
+  // check whether the field is required
+  let isRequired = false
+  if (isFunction(blueprint.required)) {
+    isRequired = blueprint.required(payload, context)
+  } else if (isBoolean(blueprint.required)) {
+    isRequired = blueprint.required
+  }
+
+  const lang = context.lang || defaultLang()
+  if (isRequired) {
+    const requiredErrorFn = createRequiredErrorFn(lang.requiredField)
+    const requiredResult = requiredErrorFn(payload)
+    if (isFullString(requiredResult)) return requiredResult
+  }
 
   if (!blueprint.error) return null
 
-  const errorResult = !isFunction(blueprint.error)
+  let errorResult = !isFunction(blueprint.error)
     ? blueprint.error
     : blueprint.error(payload, context)
+  // report provided error message if error result is true
+  if (isBoolean(errorResult)) {
+    if (errorResult) {
+      return blueprint.errorMessage ? blueprint.errorMessage : lang.fieldValidationError
+    }
+    return null
+  }
+
   return errorResult
 }
 

--- a/packages/types/src/core.ts
+++ b/packages/types/src/core.ts
@@ -33,6 +33,7 @@ export type Lang = {
   edit: string
   save: string
   requiredField: string
+  fieldValidationError: string
   formValidationError: string
 }
 


### PR DESCRIPTION
While attempting to make a multi-step form (using the `showCondition` to hide fields that are not part of the current step), I had the issue that "on next step" action, the `validateFormPerSchema()` call was returning errors from the hidden fields. I could have ignored errors from the fields that are not in the step (extra work), but for the form logic it is still problematic to have errors on fields that cannot be modified.

=> `validateFieldPerSchema()` does not perform validations on fields for which `showCondition` is false. 

I had also the issue that the `error` prop is expected to be a Boolean by Quasar's `QInput`. 

=> In `validateFieldPerSchema()` and in `evaluateError()`, when `error` is a Boolean and is `false`, the error message is looked up in the `errorMessage` prop (if not found, a default `fieldValidationError` is shown). When `error` prop returns a string the original behavior is still operational.
